### PR TITLE
Fixed missing imports on platforms that use a namespace for Arduino

### DIFF
--- a/src/TMP1075.h
+++ b/src/TMP1075.h
@@ -22,6 +22,8 @@
 #define TMP1075_H
 
 #include <stdint.h>   // uint16_t, etc.
+
+#include <Arduino.h>
 #include <Wire.h>     // TwoWire
 
 namespace TMP1075 {
@@ -88,4 +90,4 @@ namespace TMP1075 {
       uint8_t configRegister;
   };
 }
-#endif    // TMP1075.h
+#endif    // TMP1075_H


### PR DESCRIPTION
Some Arduino cores like the SAMD core use the namespace ``arduino`` for their stuff (see https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/Arduino.h). This namespace needs to be imported. Alternatively ``Arduino.h`` can be imported.